### PR TITLE
Switch from UlyssesZh/grs-action to stats-organization/github-readme-stats-action

### DIFF
--- a/.github/workflows/grs.yml
+++ b/.github/workflows/grs.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate stats card
-        uses: UlyssesZh/grs-action@v0
+        uses: stats-organization/github-readme-stats-action@v1
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           card: stats
@@ -24,10 +24,10 @@ jobs:
           path: grs/stats.svg
 
       - name: Generate languages card
-        uses: UlyssesZh/grs-action@v0
+        uses: stats-organization/github-readme-stats-action@v1
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          card: langs
+          card: top-langs
           options: username=Rollphes&layout=compact
           path: grs/langs.svg
 


### PR DESCRIPTION
Thank you for using my action, but I am deprecating it in favor of [stats-organization/github-readme-stats-action](https://github.com/stats-organization/github-readme-stats-action).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow for generating README statistics to use an improved action with enhanced compatibility and updated configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->